### PR TITLE
support for multiple domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules/

--- a/lib/express-force-domain.js
+++ b/lib/express-force-domain.js
@@ -1,15 +1,18 @@
 var url = require('url');
 
-module.exports = function(force_url){
+module.exports = function(force_url) {
 	var force_host = url.parse(force_url).host;
 
 	return function(req, res, next) {
-		var requested_host = req.header("host");
+		var requested_host = req.header('host');
 
-		if ( requested_host == force_host ) {
+		if (requested_host === force_host) {
 			next();
 		} else {
-			res.redirect(301, force_url+req.path);
+      var redirectUrl = url.resolve(force_url, req.path);
+			res.redirect(301, redirectUrl);
 		}
+
 	};
+
 }; 

--- a/lib/express-force-domain.js
+++ b/lib/express-force-domain.js
@@ -1,15 +1,25 @@
 var url = require('url');
 
-module.exports = function(force_host) {
+module.exports = function(force_hosts) {
+
+  force_hosts = (force_hosts instanceof Array) ? force_hosts : [force_hosts];
+
+  function isValidHost(host) {
+    return force_hosts.indexOf(host) !== -1;
+  }
+
+  function getRedirectHost() {
+    return force_hosts[0];
+  }
 
 	return function(req, res, next) {
 
 		var requested_host = req.header('host');
 
-		if (requested_host === force_host) {
+		if (isValidHost(requested_host)) {
 			next();
 		} else {
-      var redirectUrl = url.format(req.protocol + '://' + force_host + req.path);
+      var redirectUrl = url.format(req.protocol + '://' + getRedirectHost() + req.path);
 			res.redirect(301, redirectUrl);
 		}
 

--- a/lib/express-force-domain.js
+++ b/lib/express-force-domain.js
@@ -1,15 +1,15 @@
 var url = require('url');
 
-module.exports = function(force_url) {
-	var force_host = url.parse(force_url).host;
+module.exports = function(force_host) {
 
 	return function(req, res, next) {
+
 		var requested_host = req.header('host');
 
 		if (requested_host === force_host) {
 			next();
 		} else {
-      var redirectUrl = url.resolve(force_url, req.path);
+      var redirectUrl = url.format(req.protocol + '://' + force_host + req.path);
 			res.redirect(301, redirectUrl);
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "express-force-domain",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Force express 3.x or Connect to use a specific domain. Good for adding or removing www. and handling parked domains that redirect to your main domain.",
   "main": "./lib/express-force-domain.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -18,5 +18,11 @@
     "seo"
   ],
   "author": "Anthony Ettinger (chovy)",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "chai": "^3.2.0",
+    "express": "^4.13.3",
+    "mocha": "^2.3.0",
+    "sinon": "^1.16.1"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -22,7 +22,8 @@ describe('express-force-domain middleware', function() {
 
     app.use(forceDomain('example.com'))
 
-    request('wrong.example.com', function(res) {
+    request('wrong.example.com')
+    .then(function(res) {
 
       expect(res).to.exist;
       expect(res.statusCode).to.be.equal(301);
@@ -36,7 +37,7 @@ describe('express-force-domain middleware', function() {
         done();
       });
 
-    })
+    });
 
   });
 
@@ -48,24 +49,77 @@ describe('express-force-domain middleware', function() {
       res.end();
     });
 
-    request('example.com', function(res) {
+    request('example.com')
+    .then(function(res) {
 
       expect(res).to.exist;
       expect(res.statusCode).to.be.equal(200);
       done();
 
+    });
+
+  });
+
+  it('can be used with path prefixes', function(done) {
+
+    app.get('/baz', function(req, res) {
+      res.sendStatus(200);
+      res.end();
+    });
+
+    app.use('/foo', forceDomain('example.com'));
+    app.get('/foo/bar', function(req, res) {
+      res.sendStatus(200);
+      res.end();
+    });
+
+    request('example.com', '/foo/bar')
+    .then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+
+      return request('example.com', '/baz');
+    }).then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+
+      return request('wrong.example.com', '/foo/bar');
     })
+    .then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(301);
+
+      return request('wrong.example.com', '/baz');
+    })
+    .then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+      done();
+    });
 
   });
 
 });
 
-function request(hostname, callback) {
+function request(hostname, path, callback) {
+
+  path = path || '/';
+
+  var q = new Promise(function(resolve, reject) {
+    if(!callback) {
+      callback = resolve;
+    }
+  });
+
   http.get({
     port: serverPort,
     hostname: '127.0.0.1',
+    path: path,
     headers: {
       host: hostname
     }
   }, callback);
+
+  return q;
+
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,71 @@
+var http = require('http');
+var express = require('express');
+var expect = require('chai').expect;
+var forceDomain = require('../lib/express-force-domain');
+
+var serverPort = 4321;
+
+describe('express-force-domain middleware', function() {
+
+  var app, server;
+
+  beforeEach(function() {
+    app = express();
+    server = app.listen(serverPort);
+  });
+
+  afterEach(function() {
+    server.close();
+  });
+
+  it('responds with 301 when the requested domain does not match', function(done) {
+
+    app.use(forceDomain('example.com'))
+
+    request('wrong.example.com', function(res) {
+
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(301);
+
+      var body = ''
+      res.on('data', function(chunk) {
+        body += chunk;
+      });
+      res.on('end', function() {
+        expect(res.headers.location).to.be.equal('http://example.com/');
+        done();
+      });
+
+    })
+
+  });
+
+  it('responds with 200 when domain matches', function(done) {
+
+    app.use(forceDomain('example.com'));
+    app.get('/', function(req, res) {
+      res.sendStatus(200);
+      res.end();
+    });
+
+    request('example.com', function(res) {
+
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+      done();
+
+    })
+
+  });
+
+});
+
+function request(hostname, callback) {
+  http.get({
+    port: serverPort,
+    hostname: '127.0.0.1',
+    headers: {
+      host: hostname
+    }
+  }, callback);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -99,6 +99,46 @@ describe('express-force-domain middleware', function() {
 
   });
 
+  it('can allow multiple hosts with the first as redirect target', function(done) {
+
+
+    app.use(forceDomain([
+      'a.example.com',
+      'b.example.com'
+    ]));
+    app.get('/', function(req, res) {
+      res.sendStatus(200);
+      res.end();
+    });
+
+    request('a.example.com', '/')
+    .then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+
+      return request('b.example.com', '/');
+    }).then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(200);
+
+      return request('c.example.com', '/');
+    }).then(function(res) {
+      expect(res).to.exist;
+      expect(res.statusCode).to.be.equal(301);
+
+      var body = '';
+      res.on('data', function(chunk) {
+        body += chunk;
+      });
+      res.on('end', function() {
+        expect(res.headers.location).to.be.equal('http://a.example.com/');
+        done();
+      });
+
+    })
+
+  });
+
 });
 
 function request(hostname, path, callback) {


### PR DESCRIPTION
Adding support for multiple allowed domains (as Array), compatible with the existing interface.

With this changes error pages for requests with an invalid virtual-host can be redirected a different domain than the main application runs at. Always the first domain is picked as catchall target.
